### PR TITLE
Nixify package

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+watch_file "flake.nix" "pyproject.toml"
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
-/.env
+# Secrets
+.env
+
+# Nix
+.direnv/
+result
+
+# Python
+.ruff_cache
+.ropeproject

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,4 +1,5 @@
 """Defines optimizations for event loop."""
+
 import asyncio
 import os
 
@@ -6,3 +7,7 @@ if os.name != "nt":
     import uvloop
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+from __main__ import main
+
+__all__ = ["main"]

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,18 +1,22 @@
 """Main entry point for the audit bot."""
+
 import crescent
-import dotenv
 import hikari
 
 from bot.audit_model import AuditModel
 from bot.utils import DISCORD_TOKEN
 
-dotenv.load_dotenv()
-
-audit_bot = hikari.GatewayBot(DISCORD_TOKEN) # pyright: ignore
+audit_bot = hikari.GatewayBot(DISCORD_TOKEN)  # pyright: ignore
 
 audit_model = AuditModel()
 
 client = crescent.Client(audit_bot, audit_model)
 client.plugins.load_folder("bot.plugins")
 
-audit_bot.run()
+
+def main():
+    audit_bot.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,13 +1,15 @@
 """Define utility functions and constants for the bot."""
+
 import os
 
 import crescent
-import dotenv
 import hikari
+from dotenv import find_dotenv, load_dotenv
 
 from bot.audit_model import AuditModel
 
-dotenv.load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
+
 Plugin = crescent.Plugin[hikari.GatewayBot, AuditModel]
 
 DISCORD_TOKEN = os.environ.get("DISCORD_TOKEN")

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,90 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749776303,
+        "narHash": "sha256-OHibOvVwKqO1qvRg0r3agtd1EagW4THBcoWT7QGgcNo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e7721e37bf00fa7ea44ac3cfc9d2411284ec3ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    devshell.url = "github:numtide/devshell";
+    pyproject-nix.url = "github:nix-community/pyproject.nix";
+
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+    pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+
+      imports = with inputs; [
+        devshell.flakeModule
+      ];
+
+      perSystem =
+        { config, pkgs, ... }:
+        let
+          project = inputs.pyproject-nix.lib.project.loadPyproject {
+            projectRoot = ./.;
+          };
+
+          python = pkgs.python3;
+        in
+        {
+          packages.default =
+            (python.pkgs.buildPythonPackage (project.renderers.buildPythonPackage { inherit python; }))
+            .overrideAttrs
+              {
+                allowSubstitutes = false;
+                preferLocalBuild = true;
+              };
+
+          devshells.default =
+            let
+              env = python.withPackages (
+                project.renderers.withPackages {
+                  inherit python;
+                  extraPackages =
+                    p: with p; [
+                      python-lsp-server
+                      python-lsp-ruff
+                      pylsp-rope
+                      isort
+                      black
+                    ];
+                }
+              );
+            in
+            {
+              devshell = {
+                name = "dw-audit-bot";
+                motd = "";
+
+                packages = [
+                  env
+                ];
+              };
+              env = [
+                {
+                  name = "PYTHONPATH";
+                  prefix = "${env}/${env.sitePackages}";
+                }
+              ];
+            };
+        };
+    };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ find = {}
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "dw_audit_bot"
+version = "0.0.1"
+dependencies = [
+    "hikari",
+    "hikari-crescent",
+    "python-dotenv",
+    "pandas",
+    "uvloop",
+]
+
+[project.scripts]
+dw_audit_bot = "bot:main"
+
+[tool.setuptools.packages]
+find = {}
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adds nix infrastructure (and the ever-important pyproject.toml) to allow for easily running the bot on Nix.

Additionally, it makes dotenv load the `.env` file relative to the current working directory instead of the script's location, as it would lead to issues when the script is installed far away from where it is run.